### PR TITLE
Remove workarounds for ansible-test sanity

### DIFF
--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,7 +1,0 @@
-plugins/modules/qradar_deploy.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_log_source_management.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_offense_action.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_offense_info.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_offense_note.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_rule.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953
-plugins/modules/qradar_rule_info.py validate-modules!skip # https://github.com/ansible/ansible/issues/69953


### PR DESCRIPTION
We no longer have to ignore these files because
https://github.com/ansible/ansible/issues/69953 is fixed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>