### PR TITLE
Delete ansible as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ansible


### PR DESCRIPTION
For the execution environments, the name of the package changes to
ansible-base or ansible-core and this requirements doesn't need to
be specified necessarily as it a given that ansible engine would be
required to run the collection
