### PR TITLE
Remove ansible as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ansible


### PR DESCRIPTION
Mainly for EE purposes and
ansible engine is named as ansible-core with 2.11
