### PR TITLE
Upcap required ansible

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9,<2.11'
+requires_ansible: '>=2.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ansible


### PR DESCRIPTION
Now that 2.11 is released, and we are testing against 2.12. We can uncap
this.

Also remove ansible from requirements.txt to address future issues with
EEs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>