### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/action/qradar_analytics_rules.py
+++ b/plugins/action/qradar_analytics_rules.py
@@ -28,9 +28,10 @@ __metaclass__ = type
 
 import json
 
+from urllib.parse import quote
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
-from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.plugins.action import ActionBase
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (

--- a/plugins/action/qradar_log_sources_management.py
+++ b/plugins/action/qradar_log_sources_management.py
@@ -29,10 +29,10 @@ __metaclass__ = type
 import json
 
 from copy import copy
+from urllib.parse import quote
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
-from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.plugins.action import ActionBase
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (

--- a/plugins/httpapi/qradar.py
+++ b/plugins/httpapi/qradar.py
@@ -19,9 +19,10 @@ version_added: "1.0.0"
 
 import json
 
+from urllib.error import HTTPError
+
 from ansible.module_utils.basic import to_text
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.httpapi_base import HttpApiBase
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import BASE_HEADERS

--- a/plugins/module_utils/qradar.py
+++ b/plugins/module_utils/qradar.py
@@ -12,11 +12,10 @@ import json
 
 from copy import copy
 from ssl import CertificateError
+from urllib.parse import quote_plus
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.six.moves.urllib.parse import quote_plus
 
 
 BASE_HEADERS = {"Content-Type": "application/json", "Version": "9.1"}
@@ -89,7 +88,7 @@ def list_to_dict(input_dict):
     :returns: dict with converted all list to dict type
     """
     if isinstance(input_dict, dict):
-        for k, v in iteritems(input_dict):
+        for k, v in input_dict.items():
             if isinstance(v, dict):
                 list_to_dict(v)
             elif isinstance(v, list):

--- a/plugins/modules/log_source_management.py
+++ b/plugins/modules/log_source_management.py
@@ -76,9 +76,10 @@ EXAMPLES = """
 
 import json
 
+from urllib.parse import quote
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import (
     QRadarRequest,

--- a/plugins/modules/offense_info.py
+++ b/plugins/modules/offense_info.py
@@ -114,9 +114,10 @@ EXAMPLES = """
     var: offense_list
 """
 
+from urllib.parse import quote
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import (
     QRadarRequest,

--- a/plugins/modules/offense_note.py
+++ b/plugins/modules/offense_note.py
@@ -53,8 +53,9 @@ EXAMPLES = """
     note_text: This an example note entry that should be made on offense id 1
 """
 
+from urllib.parse import quote
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import QRadarRequest
 

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -60,8 +60,9 @@ EXAMPLES = """
 
 import json
 
+from urllib.parse import quote
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import QRadarRequest
 

--- a/plugins/modules/rule_info.py
+++ b/plugins/modules/rule_info.py
@@ -71,9 +71,10 @@ EXAMPLES = """
     var: custom_ddos_rule_info
 """
 
+from urllib.parse import quote
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.ibm.qradar.plugins.module_utils.qradar import QRadarRequest
 

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -11,12 +11,11 @@ import pytest
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. This removes it from all plugin code:

| six | stdlib |
| --- | --- |
| `six.moves.urllib.parse quote`, `quote_plus` | `urllib.parse` |
| `six.moves.urllib.error HTTPError` | `urllib.error` |
| `iteritems(d)` | `d.items()` |
| `string_types` | `str` |

All identity mappings on Python 3. The `iteritems` loop in `module_utils/qradar.py` reassigns existing keys only, so it does not resize the dict. Imports are placed in the stdlib group so the pinned isort/black pre-commit hooks stay clean. A changelog fragment is included.

Not covered, deliberately: `tests/unit/mock/procenv.py` and `tests/unit/mock/yaml_helper.py` still import `PY3`. Those are vendored copies of ansible-core test helpers that nothing in this repo imports. They looked better deleted than patched, which felt out of scope here. Happy to handle them in this PR if you prefer.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

qradar httpapi/action/module_utils plugins, offense_info, offense_note, rule, rule_info, log_source_management
